### PR TITLE
Issue where the dateFormat string was incorrect is fixed

### DIFF
--- a/AAPickerView/Classes/AAPickerView.swift
+++ b/AAPickerView/Classes/AAPickerView.swift
@@ -39,7 +39,7 @@ open class AAPickerView: UITextField {
         }
         set {
             inputView = newValue
-            dateFormatter.dateFormat = "MM/dd/YYYY"
+            dateFormatter.dateFormat = "MM/dd/yyyy"
             
         }
     }


### PR DESCRIPTION
Converting a date to a string resulted in the incorrect string because the dateFormat was previously "MM/dd/YYYY" when it should be "MM/dd/yyyy"